### PR TITLE
fix: improve styling of enterprise button

### DIFF
--- a/lib/services/core/ui/components/styles/buttons.scss
+++ b/lib/services/core/ui/components/styles/buttons.scss
@@ -14,7 +14,12 @@
   text-align: left;
   padding-left: 64px;
 
-  &.ik-provider {
+  &.enterprise-login-button {
+    text-transform: capitalize;
+  }
+
+  &.ik-provider,
+  &.enterprise-login-button {
     background-color: rgb(255, 183, 82);
     text-align: center;
     padding-left: 0px;


### PR DESCRIPTION
This PR makes it so that the "Enterprise" button is aligned correctly and also starts with an uppercase character and also inherits the same styling as the .ik-provider.